### PR TITLE
fix: move `@types/node` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@mantine/hooks": "7.16.3",
     "@mdx-js/react": "3.1.0",
     "@tabler/icons-react": "3.30.0",
-    "@types/node": "22.13.1",
     "clsx": "2.1.1",
     "posthog-js": "1.215.6",
     "react": "19.0.0",
@@ -29,6 +28,7 @@
   "devDependencies": {
     "@eslint/js": "9.20.0",
     "@mdx-js/rollup": "3.1.0",
+    "@types/node": "22.13.1",
     "@types/react": "19.0.8",
     "@types/react-dom": "19.0.3",
     "eslint": "9.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@tabler/icons-react':
         specifier: 3.30.0
         version: 3.30.0(react@19.0.0)
-      '@types/node':
-        specifier: 22.13.1
-        version: 22.13.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -51,6 +48,9 @@ importers:
       '@mdx-js/rollup':
         specifier: 3.1.0
         version: 3.1.0(acorn@8.14.0)(rollup@4.34.6)
+      '@types/node':
+        specifier: 22.13.1
+        version: 22.13.1
       '@types/react':
         specifier: 19.0.8
         version: 19.0.8


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Related issue

Fixes None

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

`@types/node` should be among `devDependencies`

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->
