### PR TITLE
fix: better heading IDs

### DIFF
--- a/src/components/MdxProvider/MdxTitle/MdxTitle.tsx
+++ b/src/components/MdxProvider/MdxTitle/MdxTitle.tsx
@@ -95,6 +95,7 @@ function getIdFrom(children: ReactNode): string {
       .trim()
       .toLowerCase()
       .replace(/\./g, '-') // some titles (configuration) contain keypath, so replace dots with hyphens
+      .replace(/\//g, '-') // replace slashes with hyphens (for the home page)
       .replace(/[^a-z0-9 -]/g, '') // remove non-alphanumeric characters
       .replace(/\s+/g, '-') // replace spaces with hyphens
       .replace(/-+/g, '-') // remove consecutive hyphens


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Related issue

Fixes #7

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

Replace `/` with `-` to give nicer IDs on the homepage. I've only replaced `/`, since replace all special chars would result in `foo (bar)` being `foo--bar-`.

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->
