### PR TITLE
feat(routing): add docs for replace in useRouter and Link

### DIFF
--- a/src/routes/documentation/components/link.mdx
+++ b/src/routes/documentation/components/link.mdx
@@ -37,5 +37,6 @@ The `Link` component behaves similarly to the `<a>` HTML tag, with a few additio
 | Prop      | Type                | Default value | Description                                                                                       |
 | --------- | ------------------- | ------------- | ------------------------------------------------------------------------------------------------- |
 | `href`    | `string` (Required) | -             | Relative path to the page in your application. Anchor names (links with hashtags) are also valid. |
+| `replace` | `boolean`           | `false`       | Whether to replace the current entry in the browser history stack.                                |
 | `preload` | `boolean`           | `true`        | Whether to preload the page if the link is within the viewport.                                   |
 | `scroll`  | `boolean`           | `true`        | Whether to preserve scroll position between navigations.                                          |

--- a/src/routes/documentation/functions/use-router.mdx
+++ b/src/routes/documentation/functions/use-router.mdx
@@ -2,7 +2,7 @@ import MetaTags from '@/components/MetaTags'
 
 <MetaTags
   title="Tuono - useRouter"
-  canonical="https://tuono.dev/documentation/functions/use-router"
+  canonical="https://tuono.dev/documentation/hooks/use-router"
 />
 
 import Breadcrumbs from '@/components/Breadcrumbs'
@@ -65,5 +65,5 @@ router.replace(path, options)
 | Name             | Type                | Default value | Description                                                       |
 | ---------------- | ------------------- | ------------- | ----------------------------------------------------------------- |
 | `path`           | `string` (Required) | -             | The path of the page you want to navigate to.                     |
-| `options`        | `PushOptions`       | -             | Optional config object for additional control.                    |
+| `options`        | `NavigationOptions` | -             | Optional config object for additional control.                    |
 | `options.scroll` | `boolean`           | `true`        | If `false` the scroll offset will be kept across page navigation. |

--- a/src/routes/documentation/functions/use-router.mdx
+++ b/src/routes/documentation/functions/use-router.mdx
@@ -2,7 +2,7 @@ import MetaTags from '@/components/MetaTags'
 
 <MetaTags
   title="Tuono - useRouter"
-  canonical="https://tuono.dev/documentation/hooks/use-router"
+  canonical="https://tuono.dev/documentation/functions/use-router"
 />
 
 import Breadcrumbs from '@/components/Breadcrumbs'
@@ -51,6 +51,16 @@ Handles client side page navigation quickly. Useful for internal links, or for w
 ```ts
 router.push(path, options)
 ```
+
+### `router.replace`
+
+Handles client side page navigation in the same way as `router.push`, but it will replace the current entry in the browser history stack.
+
+```ts
+router.replace(path, options)
+```
+
+## Router methods parameters
 
 | Name             | Type                | Default value | Description                                                       |
 | ---------------- | ------------------- | ------------- | ----------------------------------------------------------------- |

--- a/src/routes/documentation/routing/link-and-navigation.mdx
+++ b/src/routes/documentation/routing/link-and-navigation.mdx
@@ -80,4 +80,4 @@ export default function GoToAboutPage() {
 }
 ```
 
-> For more information about this hook visit the [useRouter API reference page](/documentation/hooks/use-router).
+> For more information about this hook visit the [useRouter API reference page](/documentation/functions/use-router).

--- a/src/routes/documentation/routing/link-and-navigation.mdx
+++ b/src/routes/documentation/routing/link-and-navigation.mdx
@@ -80,4 +80,4 @@ export default function GoToAboutPage() {
 }
 ```
 
-> For more information about this hook visit the [useRouter API reference page](/documentation/functions/use-router).
+> For more information about this hook visit the [useRouter API reference page](/documentation/hooks/use-router).


### PR DESCRIPTION
### Related issue

None

### Overview

Adds docs for https://github.com/tuono-labs/tuono/pull/596

~~Also fixes the previously broken navigation to `useRouter` docs from `link-and-navigation`~~
