### PR TITLE
fix(use router): fix use router link from link and navigation

### DIFF
--- a/src/routes/documentation/functions/use-router.mdx
+++ b/src/routes/documentation/functions/use-router.mdx
@@ -2,7 +2,7 @@ import MetaTags from '@/components/MetaTags'
 
 <MetaTags
   title="Tuono - useRouter"
-  canonical="https://tuono.dev/documentation/hooks/use-router"
+  canonical="https://tuono.dev/documentation/functions/use-router"
 />
 
 import Breadcrumbs from '@/components/Breadcrumbs'

--- a/src/routes/documentation/routing/link-and-navigation.mdx
+++ b/src/routes/documentation/routing/link-and-navigation.mdx
@@ -80,4 +80,4 @@ export default function GoToAboutPage() {
 }
 ```
 
-> For more information about this hook visit the [useRouter API reference page](/documentation/hooks/use-router).
+> For more information about this hook visit the [useRouter API reference page](/documentation/functions/use-router).


### PR DESCRIPTION
### Related issue

https://github.com/tuono-labs/tuono-documentation/pull/30#discussion_r1967157566

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

This PR attempts to fix a broken link to access `use-router` docs from `link-and-navigation`
