### PR TITLE
docs(tutorial/components): improve text and snippet code

### DIFF
--- a/src/routes/documentation/tutorial/components.mdx
+++ b/src/routes/documentation/tutorial/components.mdx
@@ -61,13 +61,14 @@ Now that the component is ready, import it and use it in the `index.tsx` file
 --      {pokemons.map((pokemon) => (
 --        <li key={pokemon.name}>{pokemon.name}</li>
 ++      {pokemons.map((pokemon, i) => (
-++        <PokemonLink id={i + 1} key={pokemon.name} name={pokemon.name} />
+++        <PokemonLink key={pokemon.name} id={i + 1} name={pokemon.name} />
         })}
       </ul>
 // ...
 ```
 
-Now we have working links! If you click them, you're redirected to a blank page because the `pokemons/[pokemon]` route is not implemented yet.
+Now we have working links! 
+However, clicking on them won't work yet because the `pokemons/[pokemon]` route hasn't been implemented.
 
 ## Styling a component
 
@@ -105,9 +106,9 @@ Create the `PokemonLink.module.css` stylesheet alongside `PokemonLink.tsx` and p
 }
 ```
 
-> 💡 SASS is supported out of the box. Just install the processor in the `devDependencies` with `npm i -D sass` and run `tuono dev` again
+> 💡 SASS is supported out of the box. Just install the processor in the `devDependencies` with `npm i -D sass-embedded` and run `tuono dev` again
 
-Then import the styles in the `PokemonLink` component:
+Then import the styles in the `PokemonLink` component and provide them via the `className` prop to the `Link` component:
 
 ```diff
 // src/components/PokemonLink.tsx

--- a/src/routes/documentation/tutorial/components.mdx
+++ b/src/routes/documentation/tutorial/components.mdx
@@ -67,7 +67,7 @@ Now that the component is ready, import it and use it in the `index.tsx` file
 // ...
 ```
 
-Now we have working links! 
+Now we have working links!
 However, clicking on them won't work yet because the `pokemons/[pokemon]` route hasn't been implemented.
 
 ## Styling a component

--- a/src/routes/documentation/tutorial/components.mdx
+++ b/src/routes/documentation/tutorial/components.mdx
@@ -106,7 +106,7 @@ Create the `PokemonLink.module.css` stylesheet alongside `PokemonLink.tsx` and p
 }
 ```
 
-> 💡 SASS is supported out of the box. Just install the processor in the `devDependencies` with `npm i -D sass-embedded` and run `tuono dev` again
+> 💡 SASS is supported with no extra configuration. Just install the processor in the `devDependencies` with `npm i -D sass-embedded` and run `tuono dev` again
 
 Then import the styles in the `PokemonLink` component and provide them via the `className` prop to the `Link` component:
 

--- a/src/routes/documentation/tutorial/components.mdx
+++ b/src/routes/documentation/tutorial/components.mdx
@@ -17,11 +17,11 @@ import Breadcrumbs from '@/components/Breadcrumbs'
 
 # Components
 
-## Creating a stand-alone component
+## Creating a standalone component
 
-Let’s then create the button needed for displaying the list of Pokémon.
+Let’s start by creating a link component to display each Pokémon in the list.
 
-Create the following file `src/components/PokemonLink.tsx` and fill the content with:
+Create the `src/components/PokemonLink.tsx` file and paste the following content:
 
 ```tsx
 // src/components/PokemonLink.tsx
@@ -49,7 +49,7 @@ export default function PokemonLink({
 }
 ```
 
-Now that the link is done, let’s import it into the `index.tsx` file
+Now that the component is ready, import it and use it in the `index.tsx` file
 
 ```diff
 // src/routes/index.tsx
@@ -66,12 +66,12 @@ Now that the link is done, let’s import it into the `index.tsx` file
 // ...
 ```
 
-Now the links work. Clicking on any of them, we get redirected to the 404 page because we haven’t yet implemented the `pokemons/[pokemon]` page.
-As previously said, CSS modules are enabled out of the box, so let’s make those links a little bit nicer.
+Now we have working links! If you click them, you're redirected to a blank page because the `pokemons/[pokemon]` route is not implemented yet.
 
-## Styling the component
+## Styling a component
 
-Create alongside the `PokemonLink.tsx` component the CSS module `PokemonLink.module.css` and copy the following content into it:
+As already mentioned, CSS modules are supported out of the box, so let’s make the links more presentable.
+Create the `PokemonLink.module.css` stylesheet alongside `PokemonLink.tsx` and paste the following content:
 
 ```css
 /* src/components/PokemonLink.module.css */
@@ -104,9 +104,9 @@ Create alongside the `PokemonLink.tsx` component the CSS module `PokemonLink.mod
 }
 ```
 
-> 💡 SASS is supported out of the box. Just install the processor in the devDependencies `npm i -D sass` and run again `tuono dev`
+> 💡 SASS is supported out of the box. Just install the processor in the `devDependencies` with `npm i -D sass` and run `tuono dev` again
 
-Then import the styles into the `PokemonLink` component as following:
+Then import the styles in the `PokemonLink` component:
 
 ```diff
 // src/components/PokemonLink.tsx

--- a/src/routes/documentation/tutorial/components.mdx
+++ b/src/routes/documentation/tutorial/components.mdx
@@ -38,7 +38,7 @@ export default function PokemonLink({
   name,
 }: PokemonLinkProps): JSX.Element {
   return (
-    <Link href={`/pokemons/${name}`} className={styles.link} id={id.toString()}>
+    <Link href={`/pokemons/${name}`} id={id.toString()}>
       {name}
       <img
         src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png`}
@@ -58,9 +58,10 @@ Now that the component is ready, import it and use it in the `index.tsx` file
 
 // ...
       <ul style={{ flexWrap: "wrap", display: "flex", gap: 10 }}>
-        {pokemons.map((pokemon, i) => (
---        <li key={i + 1}>{pokemon.name}</li>
-++        <PokemonLink key={i + 1} name={pokemon.name} id={i + 1} />
+--      {pokemons.map((pokemon) => (
+--        <li key={pokemon.name}>{pokemon.name}</li>
+++      {pokemons.map((pokemon, i) => (
+++        <PokemonLink id={i + 1} key={pokemon.name} name={pokemon.name} />
         })}
       </ul>
 // ...


### PR DESCRIPTION
### Related issue

Part of #42 

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

The aim of this PR is improving the [Components page of the Tutorial](https://tuono.dev/documentation/tutorial/components).

Some language tweaks were made to make the page read more nicely.

The code snippets too were improved in order to:
- be consistent with the changes introduced in #40 (`key={i + 1}` -> `key={pokemon.name}`)
- remove `className={styles.link}` from the snippet before the stylesheet is actually created
