### PR TITLE
refactor: enable `react/jsx-no-useless-fragment`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,8 +29,13 @@ const tuonoEslintConfig = tseslint.config(
   // eslint-disable-next-line import-x/no-named-as-default-member
   tseslint.configs.strictTypeChecked,
 
-  // @ts-expect-error flat is optional but always defined on runtime
-  eslintPluginReact.configs.flat.recommended,
+  {
+    ...eslintPluginReact.configs.flat.recommended,
+    rules: {
+      ...eslintPluginReact.configs.flat.recommended.rules,
+      'react/jsx-no-useless-fragment': 'error',
+    },
+  },
   eslintPluginReact.configs.flat['jsx-runtime'],
 
   {

--- a/src/components/PageWithTOC/PageWithTOC.tsx
+++ b/src/components/PageWithTOC/PageWithTOC.tsx
@@ -1,5 +1,5 @@
 import type { JSX, ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Box, Container } from '@mantine/core'
 import { useViewportSize } from '@mantine/hooks'
 
@@ -14,7 +14,6 @@ interface PageWithTOCProps {
 export function PageWithTOC({ children }: PageWithTOCProps): JSX.Element {
   const { width } = useViewportSize()
   const [footerHeight, setFooterHeight] = useState<number>(0)
-  const mainRef = useRef<HTMLDivElement>(null)
   const height = `calc(100% - ${footerHeight}px)`
 
   useEffect(() => {
@@ -24,39 +23,35 @@ export function PageWithTOC({ children }: PageWithTOCProps): JSX.Element {
       setFooterHeight(footer.clientHeight)
     }
   }, [
-    setFooterHeight,
     // Reload on window width resize
     width,
   ])
 
   return (
-    <>
-      <Box
-        style={{ zIndex: 10, height }}
-        pos="relative"
-        ref={mainRef}
-        mb={footerHeight}
-        bg="var(--mantine-color-body)"
+    <Box
+      style={{ zIndex: 10, height }}
+      pos="relative"
+      mb={footerHeight}
+      bg="var(--mantine-color-body)"
+    >
+      <Container
+        size={1000}
+        w="100%"
+        display="flex"
+        style={{ gap: 12, justifyContent: 'space-between' }}
       >
-        <Container
-          size={1000}
-          w="100%"
-          display="flex"
-          style={{ gap: 12, justifyContent: 'space-between' }}
+        <Box
+          id="mdx-root"
+          component="article"
+          mt="xl"
+          py={36}
+          className={classes.wrapper}
         >
-          <Box
-            id="mdx-root"
-            component="article"
-            mt="xl"
-            py={36}
-            className={classes.wrapper}
-          >
-            {children}
-          </Box>
+          {children}
+        </Box>
 
-          <TableOfContents />
-        </Container>
-      </Box>
-    </>
+        <TableOfContents />
+      </Container>
+    </Box>
   )
 }


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Related issue

Fixes None

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

Enable `react/jsx-no-useless-fragment` rule.

Additional improvements on `src/components/PageWithTOC/PageWithTOC.tsx`

- remove unused ref
- remove `setFooterHeight` from `useEffect` dependencies (a setter is a stable method)
- remove useless fragment

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->
