### PR TITLE
feat(tutorial/dynamic-routes): Improve styles of `PokemonView` component

### DIFF
--- a/src/routes/documentation/tutorial/dynamic-routes.mdx
+++ b/src/routes/documentation/tutorial/dynamic-routes.mdx
@@ -149,10 +149,15 @@ To have the proper style consider adding a new css module file:
 
 ```css
 /* src/components/PokemonView.module.css */
+/* src/components/PokemonView.module.css */
 .pokemon {
   display: flex;
   justify-content: space-between;
   margin-top: 20px;
+  border-radius: 18px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px;
+  padding: 16px 32px;
+  background: white;
 }
 
 .name {
@@ -161,13 +166,18 @@ To have the proper style consider adding a new css module file:
 }
 
 .pokemon img {
-  width: 400px;
+  width: 250px;
+  height: 100%;
 }
 
 .spec {
   display: flex;
   font-size: 18px;
   margin-top: 10px;
+
+  > dt {
+    margin-right: 6px;
+  }
 }
 
 .label {

--- a/src/routes/documentation/tutorial/dynamic-routes.mdx
+++ b/src/routes/documentation/tutorial/dynamic-routes.mdx
@@ -149,7 +149,6 @@ To have the proper style consider adding a new css module file:
 
 ```css
 /* src/components/PokemonView.module.css */
-/* src/components/PokemonView.module.css */
 .pokemon {
   display: flex;
   justify-content: space-between;
@@ -167,7 +166,6 @@ To have the proper style consider adding a new css module file:
 
 .pokemon img {
   width: 250px;
-  height: 100%;
 }
 
 .spec {


### PR DESCRIPTION
### Related issue

Part of #42

### Overview

The aim of this PR is improving the styles of the `PokemonView` component in the Dynamic routes tutorial page.
It is not a vital change, but, since we're asking the user to copy-paste styles, we might as well give it a more polished look.

| Before | After |
|--------|--------|
|<img width="843" alt="Screenshot 2025-03-06 at 22 01 57" src="https://github.com/user-attachments/assets/5321f47a-7840-4e1b-9a4a-3541d29d365e" /> | <img width="807" alt="Screenshot 2025-03-06 at 22 01 27" src="https://github.com/user-attachments/assets/2b64eecb-fe83-406a-9ef6-58796012dd8f" />| 