### PR TITLE
fix: sidebar routing and hydration mismatch

### DIFF
--- a/src/components/SideNavigation/SideNavigation.tsx
+++ b/src/components/SideNavigation/SideNavigation.tsx
@@ -32,6 +32,9 @@ function TreeItemContent({
         href={page.path}
         className={cx(isActive && styles.active, 'body-2')}
         aria-label={page.title}
+        onClick={(e): void => {
+          e.preventDefault()
+        }}
       >
         {page.title}
       </Link>
@@ -45,7 +48,6 @@ function TreeItemContent({
 }
 
 function TreeBlock({ page }: { page: Page }): JSX.Element {
-  const router = useRouter()
   return (
     <div className={styles.block}>
       <h3 className={styles['block-title']}>{page.title}</h3>
@@ -57,9 +59,6 @@ function TreeBlock({ page }: { page: Page }): JSX.Element {
               id={subPage.path}
               key={subPage.path}
               className={styles['sub-page']}
-              onAction={(): void => {
-                router.push(subPage.path)
-              }}
             >
               <AriaTreeItemContent>
                 {({ hasChildItems }) => (

--- a/src/components/SideNavigation/SideNavigation.tsx
+++ b/src/components/SideNavigation/SideNavigation.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react'
 import cx from 'clsx'
-import { Link, useRouter } from 'tuono'
+import { Link } from 'tuono'
 import {
   Tree,
   TreeItem,

--- a/src/contexts/MdxProvider.tsx
+++ b/src/contexts/MdxProvider.tsx
@@ -21,7 +21,7 @@ export function MdxProvider({ children }: MdxProviderProps): JSX.Element {
           p: (props) => <p {...props} />,
           hr: () => <hr />,
           pre: (props) => <pre {...props} style={{ width: '100px' }} />,
-          code: (props) => <pre {...props} />,
+          code: (props) => <code {...props} />,
         }}
       >
         {children}


### PR DESCRIPTION
<!--
👋 Thank you for your Pull Request 🙏
-->

### Related issue

Fixes None

<!-- Replace the content with "None" if you haven't an issue to link -->

### Overview

<!--

Explain the context and why you're making that change.
What is the problem you're trying to solve?
If a new feature is being added,
describe the intended use case that feature fulfills.

-->

- [x] Prevents sidebar navigation to trigger the router twice (creating multiple entries in the history stack)
- [x] Fix hydration mismatch caused by the `code` component
